### PR TITLE
feat(cosmetic): update to match apple guidelines

### DIFF
--- a/export/Icon-bg.svg
+++ b/export/Icon-bg.svg
@@ -1,1 +1,18 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg width="100%" height="100%" viewBox="0 0 768 768" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"><rect id="Logo--Avatar-" serif:id="Logo (Avatar)" x="0" y="0" width="768" height="768" style="fill:none;"/><rect id="Background" x="0" y="0" width="768" height="768" style="fill:#5849be;"/><circle id="White" cx="384" cy="384.002" r="317.136" style="fill:#fff;"/><path id="Pupil" d="M316.487,141.518c21.488,-5.978 44.13,-9.174 67.513,-9.174c138.893,0 251.656,112.763 251.656,251.656c0,138.893 -112.763,251.656 -251.656,251.656c-138.893,0 -251.656,-112.763 -251.656,-251.656c0,-23.38 3.195,-46.02 9.172,-67.506c22.702,32.968 60.708,54.597 103.725,54.597c69.459,0 125.85,-56.39 125.85,-125.847c0,-43.019 -21.633,-81.025 -54.604,-103.726Z" style="fill:#5849be;"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 768 768" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <defs>
+        <linearGradient id="fadeGrad" y2="1" x2="0">
+            <stop offset="0.1" stop-color="white" stop-opacity="0"/>
+            <stop offset="1" stop-color="white" stop-opacity=".4"/>
+        </linearGradient>
+        <mask id="fade" maskContentUnits="objectBoundingBox">
+          <rect width="1" height="1" fill="url(#fadeGrad)"/>
+        </mask>
+    </defs>
+    <rect id="DropShadow" y="16" width="768" height="752" rx="192" mask="url(#fade)" />
+    <rect id="Logo--Avatar-" serif:id="Logo (Avatar)" x="0" y="0" width="768" height="768" style="fill:none;"/>
+    <rect id="Background" x="8" width="752" height="750" rx="192" style="fill:#5849be;"/>
+    <circle id="White" cx="384" cy="384.002" r="317.136" style="fill:#fff;"/>
+    <path id="Pupil" d="M316.487,141.518c21.488,-5.978 44.13,-9.174 67.513,-9.174c138.893,0 251.656,112.763 251.656,251.656c0,138.893 -112.763,251.656 -251.656,251.656c-138.893,0 -251.656,-112.763 -251.656,-251.656c0,-23.38 3.195,-46.02 9.172,-67.506c22.702,32.968 60.708,54.597 103.725,54.597c69.459,0 125.85,-56.39 125.85,-125.847c0,-43.019 -21.633,-81.025 -54.604,-103.726Z" style="fill:#5849be;"/>
+</svg>

--- a/export/Icon.svg
+++ b/export/Icon.svg
@@ -1,1 +1,20 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg width="100%" height="100%" viewBox="0 0 768 768" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"><rect id="Logo" x="0" y="0" width="768" height="768" style="fill:none;"/><clipPath id="_clip1"><rect x="0" y="0" width="768" height="768"/></clipPath><g clip-path="url(#_clip1)"><circle id="White" cx="384" cy="384.002" r="384" style="fill:#fff;"/><path id="Pupil" d="M302.253,90.394c26.018,-7.239 53.434,-11.109 81.747,-11.109c168.177,0 304.715,136.538 304.715,304.715c0,168.176 -136.538,304.715 -304.715,304.715c-168.177,0 -304.715,-136.539 -304.715,-304.715c0,-28.31 3.869,-55.723 11.107,-81.739c27.488,39.918 73.506,66.108 125.594,66.108c84.102,0 152.383,-68.279 152.383,-152.38c0,-52.089 -26.193,-98.109 -66.116,-125.595Z" style="fill:#5849be;"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg width="100%" height="100%" viewBox="0 0 768 768" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <defs>
+        <linearGradient id="fadeGrad" y2="1" x2="0">
+            <stop offset="0.1" stop-color="white" stop-opacity="0"/>
+            <stop offset="1" stop-color="white" stop-opacity=".4"/>
+        </linearGradient>
+        <mask id="fade" maskContentUnits="objectBoundingBox">
+          <rect width="1" height="1" fill="url(#fadeGrad)"/>
+        </mask>
+    </defs>
+    <rect id="Logo" x="0" y="0" width="768" height="768" style="fill:none;" />
+    <clipPath id="_clip1">
+        <rect x="0" y="0" width="768" height="768" />
+    </clipPath>
+    <g clip-path="url(#_clip1)">
+        <rect id="DropShadow" y="16" width="768" height="752" rx="192" mask="url(#fade)" />
+        <rect id="White" x="8" width="752" height="750" rx="192" style="fill:#fff;" />
+        <path id="Pupil" d="M302.253,90.394c26.018,-7.239 53.434,-11.109 81.747,-11.109c168.177,0 304.715,136.538 304.715,304.715c0,168.176 -136.538,304.715 -304.715,304.715c-168.177,0 -304.715,-136.539 -304.715,-304.715c0,-28.31 3.869,-55.723 11.107,-81.739c27.488,39.918 73.506,66.108 125.594,66.108c84.102,0 152.383,-68.279 152.383,-152.38c0,-52.089 -26.193,-98.109 -66.116,-125.595Z" style="fill:#5849be;"/>
+    </g>
+</svg>

--- a/export/Icon.svg
+++ b/export/Icon.svg
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg width="100%" height="100%" viewBox="0 0 768 768" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 768 768" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
     <defs>
         <linearGradient id="fadeGrad" y2="1" x2="0">
             <stop offset="0.1" stop-color="white" stop-opacity="0"/>


### PR DESCRIPTION
The current icon does not conform to Apple's new design guildelines for macOS Big Sur (11.0) and onwards:

![olddock](https://user-images.githubusercontent.com/91137069/134560819-c75adb3b-c1a9-4e7c-a7bb-5f22c43207bd.png)

https://developer.apple.com/design/human-interface-guidelines/macos/icons-and-images/app-icon

It should be a .25 radius rounded square, and a .4 drop-shadow. See the example icon resource render, as it would appear in the dock:

![newdock](https://user-images.githubusercontent.com/91137069/134560829-eaefa36d-b8c2-41fb-9c38-d1fc3e1b4118.png)

**Important:** I don't have Serif Affinity Designer, so I was unable to update the actual render, however you could use this PR as an example to regenerate the whole icon set, just need to add the rectangle and filter to the Serif file.